### PR TITLE
feat: user-login-jwt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,13 @@ dependencies {
     implementation 'org.json:json:20240303'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.batch:spring-batch-test'
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+    //JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/part35teammonew/config/CorsConfig.java
+++ b/src/main/java/com/example/part35teammonew/config/CorsConfig.java
@@ -1,0 +1,4 @@
+package com.example.part35teammonew.config;
+
+public class CorsConfig {
+}

--- a/src/main/java/com/example/part35teammonew/config/SecurityConfig.java
+++ b/src/main/java/com/example/part35teammonew/config/SecurityConfig.java
@@ -1,0 +1,4 @@
+package com.example.part35teammonew.config;
+
+public class SecurityConfig {
+}

--- a/src/main/java/com/example/part35teammonew/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/part35teammonew/domain/user/controller/AuthController.java
@@ -1,0 +1,4 @@
+package com.example.part35teammonew.domain.user.controller;
+
+public class AuthController {
+}

--- a/src/main/java/com/example/part35teammonew/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/part35teammonew/domain/user/controller/UserController.java
@@ -1,0 +1,59 @@
+package com.example.part35teammonew.domain.user.controller;
+
+import com.example.part35teammonew.domain.user.dto.UserDto;
+import com.example.part35teammonew.domain.user.dto.UserRegisterRequest;
+import com.example.part35teammonew.domain.user.dto.UserUpdateRequest;
+import com.example.part35teammonew.domain.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Validated
+@RestController
+@RequestMapping("api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    // 회원가입
+    @PostMapping
+    ResponseEntity<UserDto> registerUser(@RequestBody @Valid UserRegisterRequest request){
+        UserDto createdUserDto = userService.register(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(createdUserDto);
+    }
+
+    // 닉네임 수정
+    @PutMapping("/{userId}")
+    ResponseEntity<UserDto> updateUser(@PathVariable(value = "userId") UUID userId, @RequestBody UserUpdateRequest request) {
+        UserDto updatedUserDto = userService.update(userId, request);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(updatedUserDto);
+    }
+
+    // 회원 논리 삭제
+    @DeleteMapping("/{userId}")
+    ResponseEntity<Void> deleteUserLogical(@PathVariable(value = "userId") UUID userId){
+        userService.deleteLogical(userId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .build();
+    }
+
+    // 회원 물리 삭제
+    @DeleteMapping("/{userId}/hard")
+    ResponseEntity<Void> deleteUserPhysical(@PathVariable(value = "userId") UUID userId){
+            userService.deletePhysical(userId);
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .build();
+    }
+}

--- a/src/main/java/com/example/part35teammonew/domain/user/dto/TokenDto.java
+++ b/src/main/java/com/example/part35teammonew/domain/user/dto/TokenDto.java
@@ -1,0 +1,4 @@
+package com.example.part35teammonew.domain.user.dto;
+
+public class TokenDto {
+}

--- a/src/main/java/com/example/part35teammonew/domain/user/dto/UserDto.java
+++ b/src/main/java/com/example/part35teammonew/domain/user/dto/UserDto.java
@@ -19,18 +19,12 @@ public class UserDto {
 
     private LocalDateTime createdAt;
 
-    private LocalDateTime updatedAt;
-
-    private boolean isDeleted;
-
     public static UserDto fromEntity(User user) {
         return UserDto.builder()
                 .id(user.getId())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .createdAt(user.getCreatedAt())
-                .updatedAt(user.getUpdatedAt())
-                .isDeleted(user.isDeleted())
                 .build();
     }
 }

--- a/src/main/java/com/example/part35teammonew/domain/user/dto/UserLoginRequest.java
+++ b/src/main/java/com/example/part35teammonew/domain/user/dto/UserLoginRequest.java
@@ -1,0 +1,4 @@
+package com.example.part35teammonew.domain.user.dto;
+
+public class UserLoginRequest {
+}

--- a/src/main/java/com/example/part35teammonew/domain/user/dto/UserRegisterRequest.java
+++ b/src/main/java/com/example/part35teammonew/domain/user/dto/UserRegisterRequest.java
@@ -1,0 +1,27 @@
+package com.example.part35teammonew.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserRegisterRequest {
+
+    @NotBlank(message = "이메일은 필수값입니다.")
+    @Email(message = "이메일 형식이 아닙니다.")
+    String email;
+
+    @NotBlank(message = "닉네임은 필수값입니다.")
+    @Size(min = 2, max = 16, message = "닉네임은 2자 이상 16자 이하여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,16}$", message = "닉네임은 2~16자의 한글, 영어 또는 숫자만 사용 가능합니다.")
+    String nickname;
+
+    @NotBlank(message = "비밀번호는 필수값입니다.")
+    @Size(min = 8, max = 16, message = "비밀번호는 8자 이상 16자 이하여야 합니다.")
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+    String password;
+}

--- a/src/main/java/com/example/part35teammonew/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/example/part35teammonew/domain/user/dto/UserUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.example.part35teammonew.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserUpdateRequest {
+
+    @NotBlank(message = "닉네임은 필수값입니다.")
+    @Size(min = 2, max = 16, message = "닉네임은 2자 이상 16자 이하여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,16}$", message = "닉네임은 2~16자의 한글, 영어 또는 숫자만 사용 가능합니다.")
+    String nickname;
+}

--- a/src/main/java/com/example/part35teammonew/domain/user/entity/User.java
+++ b/src/main/java/com/example/part35teammonew/domain/user/entity/User.java
@@ -69,7 +69,7 @@ public class User {
     this.nickname = nickname;
   }
 
-  public void delete() {
+  public void deleteLogical() {
     this.isDeleted = true;
     this.deletedAt = LocalDateTime.now();
   }

--- a/src/main/java/com/example/part35teammonew/domain/user/service/UserService.java
+++ b/src/main/java/com/example/part35teammonew/domain/user/service/UserService.java
@@ -1,21 +1,25 @@
 package com.example.part35teammonew.domain.user.service;
 
 import com.example.part35teammonew.domain.user.dto.UserDto;
-import com.example.part35teammonew.domain.user.entity.User;
+import com.example.part35teammonew.domain.user.dto.UserRegisterRequest;
+import com.example.part35teammonew.domain.user.dto.UserUpdateRequest;
 import java.util.UUID;
 
 public interface UserService {
 
     // 회원가입
-    UserDto create(User user);
+    UserDto register(UserRegisterRequest request);
 
     // 닉네임 수정
-    UserDto update(UUID userId, String nickname);
+    UserDto update(UUID userId, UserUpdateRequest request);
 
-    // 회원 삭제 (물리 삭제 여부 false -> 논리 삭제)
-    void delete(UUID userId, boolean isPhysical);
+    // 회원 논리 삭제
+    void deleteLogical(UUID userId);
+
+    // 회원 물리 삭제
+    void deletePhysical(UUID userId);
 
     // 로그인 (JWT 토큰 반환)
-    String login(User user);
+//  UserDto login(UserLoginRequest request); TODO 아직 구현체에 구현 전이라 일단 주석 처리
 
 }

--- a/src/main/java/com/example/part35teammonew/domain/user/service/impl/CustomUserDetails.java
+++ b/src/main/java/com/example/part35teammonew/domain/user/service/impl/CustomUserDetails.java
@@ -1,0 +1,4 @@
+package com.example.part35teammonew.domain.user.service.impl;
+
+public class CustomUserDetails {
+}

--- a/src/main/java/com/example/part35teammonew/domain/user/service/impl/CustomUserDetailsService.java
+++ b/src/main/java/com/example/part35teammonew/domain/user/service/impl/CustomUserDetailsService.java
@@ -1,0 +1,4 @@
+package com.example.part35teammonew.domain.user.service.impl;
+
+public class CustomUserDetailsService {
+}

--- a/src/main/java/com/example/part35teammonew/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/part35teammonew/domain/user/service/impl/UserServiceImpl.java
@@ -1,0 +1,67 @@
+package com.example.part35teammonew.domain.user.service.impl;
+
+import com.example.part35teammonew.domain.user.dto.UserDto;
+import com.example.part35teammonew.domain.user.dto.UserRegisterRequest;
+import com.example.part35teammonew.domain.user.dto.UserUpdateRequest;
+import com.example.part35teammonew.domain.user.entity.User;
+import com.example.part35teammonew.domain.user.repository.UserRepository;
+import com.example.part35teammonew.domain.user.service.UserService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+// TODO 로그, 커스텀 예외 처리
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private UserRepository userRepository;
+
+    // 회원가입
+    @Override
+    public UserDto register(UserRegisterRequest request) {
+
+        User user = User.builder()
+                        .email(request.getEmail())
+                        .nickname(request.getNickname())
+                        .password(request.getPassword())
+                        .build();
+        userRepository.save(user);
+
+        return UserDto.builder()
+                .email(request.getEmail())
+                .nickname(request.getNickname())
+                .build();
+    }
+
+    // 닉네임 수정
+    @Transactional
+    @Override
+    public UserDto update(UUID userId, UserUpdateRequest request){
+        User user = userRepository.findById(userId)
+                .orElseThrow(); // TODO 커스텀 예외 추가 후 수정 예정
+        user.updateNickname(request.getNickname());
+        return UserDto.builder()
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+    }
+
+    // 회원 논리 삭제
+    @Override
+    public void deleteLogical(UUID userId){
+        User user = userRepository.findById(userId)
+                .orElseThrow();
+        user.deleteLogical();
+    }
+
+    // 회원 물리 삭제
+    @Override
+    public void deletePhysical(UUID userId){
+            userRepository.deleteById(userId); // TODO cascade 옵션을 통해 (?) 연관관계 객체도 삭제
+    }
+}

--- a/src/main/java/com/example/part35teammonew/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/part35teammonew/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,4 @@
+package com.example.part35teammonew.jwt;
+
+public class JwtAuthenticationEntryPoint {
+}

--- a/src/main/java/com/example/part35teammonew/jwt/JwtFilter.java
+++ b/src/main/java/com/example/part35teammonew/jwt/JwtFilter.java
@@ -1,0 +1,4 @@
+package com.example.part35teammonew.jwt;
+
+public class JwtFilter {
+}

--- a/src/main/java/com/example/part35teammonew/jwt/JwtSecurityConfig.java
+++ b/src/main/java/com/example/part35teammonew/jwt/JwtSecurityConfig.java
@@ -1,0 +1,4 @@
+package com.example.part35teammonew.jwt;
+
+public class JwtSecurityConfig {
+}

--- a/src/main/java/com/example/part35teammonew/jwt/TokenProvider.java
+++ b/src/main/java/com/example/part35teammonew/jwt/TokenProvider.java
@@ -1,0 +1,4 @@
+package com.example.part35teammonew.jwt;
+
+public class TokenProvider {
+}

--- a/src/main/java/com/example/part35teammonew/util/SecurityUtil.java
+++ b/src/main/java/com/example/part35teammonew/util/SecurityUtil.java
@@ -1,0 +1,4 @@
+package com.example.part35teammonew.util;
+
+public class SecurityUtil {
+}

--- a/src/test/java/com/example/part35teammonew/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/example/part35teammonew/domain/user/repository/UserRepositoryTest.java
@@ -69,7 +69,7 @@ class UserRepositoryTest {
         User user = userRepository.save(User.create("del@example.com", "delNick", "pw"));
 
         // when
-        user.delete();
+        user.deleteLogical();
         userRepository.save(user);
 
         // then

--- a/src/test/java/com/example/part35teammonew/domain/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/example/part35teammonew/domain/user/service/impl/UserServiceImplTest.java
@@ -1,0 +1,146 @@
+package com.example.part35teammonew.domain.user.service.impl;
+
+import com.example.part35teammonew.domain.user.dto.UserDto;
+import com.example.part35teammonew.domain.user.dto.UserRegisterRequest;
+import com.example.part35teammonew.domain.user.dto.UserUpdateRequest;
+import com.example.part35teammonew.domain.user.entity.User;
+import com.example.part35teammonew.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    private UUID userId;
+    private User user;
+    private UserRegisterRequest registerRequest;
+    private UserUpdateRequest updateRequest;
+
+    @BeforeEach
+    void setup() {
+        userId = UUID.randomUUID();
+
+        user = User.builder()
+                .id(userId)
+                .email("test@example.com")
+                .nickname("testuser")
+                .password("Password123!")
+                .build();
+
+        registerRequest = UserRegisterRequest.builder()
+                .email("test@example.com")
+                .nickname("testuser")
+                .password("Password123!")
+                .build();
+
+        updateRequest = UserUpdateRequest.builder()
+                .nickname("updatedUser")
+                .build();
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 테스트")
+    void registerUser_Success() {
+        // Given
+        when(userRepository.save(any(User.class))).thenReturn(user);
+
+        // When
+        UserDto result = userService.register(registerRequest);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getEmail()).isEqualTo(registerRequest.getEmail());
+        assertThat(result.getNickname()).isEqualTo(registerRequest.getNickname());
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("닉네임 수정 성공 테스트")
+    void updateNickname_Success() {
+        // Given
+        User updatedUser = User.builder()
+                .id(userId)
+                .email("test@example.com")
+                .nickname("updatedUser")
+                .password("Password123!")
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // When
+        UserDto result = userService.update(userId, updateRequest);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getNickname()).isEqualTo(updateRequest.getNickname());
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("닉네임 수정 실패 테스트 - 사용자 없음")
+    void updateNickname_UserNotFound() {
+        // Given
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(NoSuchElementException.class, () -> userService.update(userId, updateRequest));
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("회원 논리 삭제 성공 테스트")
+    void deleteUserLogical_Success() {
+        // Given
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // When
+        userService.deleteLogical(userId);
+
+        // Then
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("회원 논리 삭제 실패 테스트 - 사용자 없음")
+    void deleteUserLogical_UserNotFound() {
+        // Given
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(NoSuchElementException.class, () -> userService.deleteLogical(userId));
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("회원 물리 삭제 성공 테스트")
+    void deleteUserPhysical_Success() {
+        // Given
+        doNothing().when(userRepository).deleteById(userId);
+
+        // When
+        userService.deletePhysical(userId);
+
+        // Then
+        verify(userRepository, times(1)).deleteById(userId);
+    }
+}

--- a/src/test/java/com/example/part35teammonew/notification/NotificationRepositoryTest.java
+++ b/src/test/java/com/example/part35teammonew/notification/NotificationRepositoryTest.java
@@ -4,9 +4,10 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.example.part35teammonew.domain.notification.Enum.NotificationType;
 import com.example.part35teammonew.domain.notification.entity.Notification;
-import com.example.part35teammonew.domain.notification.repository.NoticeRepository;
 import java.util.Optional;
 import java.util.UUID;
+
+import com.example.part35teammonew.domain.notification.repository.NotificationRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +17,7 @@ import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 public class NotificationRepositoryTest {
 
   @Autowired
-  private NoticeRepository noticeRepository;
+  private NotificationRepository noticeRepository;
 
   @Test
   @DisplayName("댓글 알림 생성 및 저장 테스트")


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


### 반영 브랜치

feature/user-login-jwt -> develop

### 변경 사항 ⭐⭐⭐
**[수정] 파일 내용들이 제대로 안올라갔는지 많이 누락되어있어 code with me로 내용 채워넣음 ...**
- API 명세서 상 로그인은 로그인 후 API 기능 요청할 때마다 헤더에 사용자ID를 포함해 요청하는 방식이었습니다. 그런데 이 부분을 잘 알지 못하여 jwt로 해석하고 jwt를 공부한 후 적용하던 중 뒤늦게 이 사실을 알았습니다. (API 명세서 속 응답 반환 부분에 토큰이 없다는 걸 뒤늦게 인지하고 잘 몰라서 헤더에 포함된 걸 토큰 반환이라고 해석하고 있었네요,,)
- 주강사님이 기존에 API 명세서 로그인은 그냥 제일 빨리 구현 가능한 걸로 설계가 된거라 하셨습니다. 실제로 구현이 되게 간단해서 저희 팀원 5명이 각자 도메인 하나를 맡았는데, 하나의 도메인 비중을 차지할 정도가 못된다 생각했고, 주강사님께 질문드려본 바로도 jwt로 리팩토링하는 방법이 충분히 가능하다고 판단이 돼서 일단 그대로 jwt 진행했습니다.
- 그 결과 포스트맨으로 로직이 잘 굴러가서 일단 PR을 하겠습니다.
⭐ 문제는 프론트엔드코드인데, jwt가 돌아가기 위해 일부만 조금 수정이 필요해서 이 부분은 챗지피티를 통해서 수정을 했습니다. 이 부분은 나중에 프론트랑 연결할 때 더 수정봐야할 것 같습니다.
⭐ 만약 최후에 프론트 코드 때문에 로그인이 실패할 걸 대비해 기존 API 명세서 로그인 버전도 브랜치 따로 파서 구현해놓긴 했습니다.
- jtw 포스트맨 테스트 결과 첨부해 PR 올립니당

### 테스트 결과
- 회원가입
![image](https://github.com/user-attachments/assets/89ff6366-be76-4ea6-b425-6d340060799e)
- 로그인 (토큰 반환됨)
![image](https://github.com/user-attachments/assets/2f09d06e-9833-4b0e-934e-9214dcee6d0b)
- 닉네임 수정
![image](https://github.com/user-attachments/assets/e63ea122-3d85-4080-825f-a82fe09be462)
- 논리 삭제
![image](https://github.com/user-attachments/assets/58690988-5ecc-472a-bbd0-f636545c5476)
![image](https://github.com/user-attachments/assets/16783515-97a6-4acd-96f4-74abfc6913d5)
- 물리삭제 : 포스트맨으로는 성공이라고 뜨는데 DB에 삭제 반영이 안됩니다. 머지 후에 다른 도메인 Cascade 옵션 확인도하면서 수정봐야할 것 같습니다. 
